### PR TITLE
docs: README hero screenshots (dial + week)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 A calm AI companion that runs your week *with* you — and keeps you well while you run it.
 Local-first, research-backed, yours.
 
+<p align="center">
+  <img src="app/shots/1-focus-rest.png" alt="MEW's focus dial — a 12-hour ring showing the current block, time remaining, and the day's shape at rest" width="920">
+</p>
+<p align="center">
+  <img src="app/shots/4-week.png" alt="The week view — time-true columns, the live day highlighted, and MEW suggesting a right-size with its research citation in chat" width="920">
+</p>
+
 > block thursday morning for the deck, keep friday afternoon free
 
 **Positive only.** A completed task is *a mew* — the only thing MEW ever counts. No streaks,


### PR DESCRIPTION
Pre-Show-HN polish: the README had zero images. Adds the two canonical seeded shots (already tracked, audit-cleared, fictional data) right under the tagline — the focus dial as the distinctive hero, the week view as the substance shot (it happens to show a research-cited nudge live, which is the pitch in one image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eh4NzeCUEyacXgqU7Scw4S